### PR TITLE
Fix test-rflow problems

### DIFF
--- a/tests/testthat/test-rflow.R
+++ b/tests/testthat/test-rflow.R
@@ -8,7 +8,7 @@ test_that("make_rflow() works", {
     f <- function() { i <<- i + 1; i }
     rf <- make_rflow(f)
 
-    expect_warning(rf <- make_rflow(f), NA)
+    expect_warning(rf, NA)
     expect_equal(f(), 1)
     expect_equal(f(), 2)
     # +1 due to f running one more time
@@ -27,7 +27,7 @@ test_that("make_rflow() works with function with one argument", {
     f <- function(j) { i <<- i + 1; i }
     rf <- make_rflow(f)
 
-    expect_warning(rf <- make_rflow(f), NA)
+    expect_warning(rf, NA)
     expect_equal(f(), 1)
     expect_equal(f(), 2)
     # +1 due to f running one more time

--- a/tests/testthat/test-rflow.R
+++ b/tests/testthat/test-rflow.R
@@ -44,7 +44,6 @@ test_that("make_rflow() works with function with variadic arguments", {
     # no arguments, just a side effect to determine when f ran
     i <- 0
     f <- function(...) { i <<- i + 1; i }
-    rf <- make_rflow(f)
 
     expect_warning(rf <- make_rflow(f), NA)
     expect_equal(f(), 1)
@@ -55,23 +54,6 @@ test_that("make_rflow() works with function with variadic arguments", {
     expect_equal(collect(rf()), 3)
 
     delete_eddy(eddy_name = .EDDY_DEFAULT_NAME)
-})
-
-
-test_that("make_rflow() works with function with variadic arguments", {
-
-    # no arguments, just a side effect to determine when f ran
-    i <- 0
-    f <- function(...) { i <<- i + 1; i }
-    rf <- make_rflow(f)
-    
-    expect_warning(rf <- make_rflow(f), NA)
-    expect_equal(f(), 1)
-    expect_equal(f(), 2)
-    # +1 due to f running one more time
-    expect_equal(collect(rf()), 3)
-    # +0 due to remembering previous value
-    expect_equal(collect(rf()), 3)
 })
 
 
@@ -228,6 +210,8 @@ test_that("interface of wrapper matches interface of cached function", {
     expect_equal(formals(fn), formals(make_rflow(fn)))
     expect_equal(formals(runif), formals(make_rflow(runif)))
     expect_equal(formals(paste), formals(make_rflow(paste)))
+    
+    delete_eddy(eddy_name = .EDDY_DEFAULT_NAME)
 })
 
 
@@ -467,4 +451,6 @@ test_that("check_state() works", {
     
     expect_equal(rflow$check_state(), TRUE) # we have out_hash in eddy
     expect_equal(rflow$check_state(5), TRUE) # invalid index after state
+    
+    delete_eddy(eddy_name = .EDDY_DEFAULT_NAME)
 })


### PR DESCRIPTION
- Delete duplicate functions.
- Make sure default eddy is reset after each function.